### PR TITLE
fix crash in CollectGageStatistics

### DIFF
--- a/Libraries/FzCommon/SensorHelpers.cs
+++ b/Libraries/FzCommon/SensorHelpers.cs
@@ -180,9 +180,9 @@ namespace FzCommon
                 if (result != null)
                 {
                     result.Result = "Saved as deleted (LScale is missing)";
+                    result.ShouldSave = true;
+                    result.ShouldSaveAsDeleted = true;
                 }
-                result.ShouldSave = true;
-                result.ShouldSaveAsDeleted = true;
                 return false;
             }
 


### PR DESCRIPTION
silly error in SensorHelpers; CollectGageStatistics passes null for "result" in ShouldIgnoreReading(), and ShouldIgnoreReading()'s null check was incomplete.