### PR TITLE
forecast sms testing page; make dashboard have two-pane view always

### DIFF
--- a/Clients/react-fz-client/src/components/DashboardGage.js
+++ b/Clients/react-fz-client/src/components/DashboardGage.js
@@ -15,7 +15,7 @@ export default function DashboardGage({ gage, gageStatus, viewDetails, resize, i
       id={"gage_" + gage.id}
     >
       <div className="row row-hover gage-row">
-        <div className="col-lg-8 col-md-12 col-sm-12 col-xs-12 box">
+        <div className="col-lg-12 col-md-12 col-sm-12 col-xs-12 dashboard-gage-box">
           <div className="Title">
             <span className="types types-text" style={{ float: "right" }}>
               {gage.id}
@@ -28,7 +28,7 @@ export default function DashboardGage({ gage, gageStatus, viewDetails, resize, i
             style={{ padding: 0 }}
           >
             <div
-              className="col-lg-5 col-md-6 col-sm-5 col-xs-5 float-left"
+              className="col-lg-6 col-md-6 col-sm-5 col-xs-5 float-left"
               style={{ marginLeft: "-16px", width: "auto"}}
             >
               {!gageStatus
@@ -63,7 +63,7 @@ export default function DashboardGage({ gage, gageStatus, viewDetails, resize, i
             </div>
           </div>
         </div>
-        <div className="col-lg-4 col-md-12 col-sm-12 col-xs-12 chart-box">
+        <div className="col-lg-12 col-md-12 col-sm-12 col-xs-12 chart-box">
           <GageChart
             gage={gage}
             gageStatus={gageStatus}

--- a/Clients/react-fz-client/src/style/Dashboard.css
+++ b/Clients/react-fz-client/src/style/Dashboard.css
@@ -179,12 +179,17 @@ body {
   min-height: 170px;
 }
 
-.box {
+.dashboard-gage-box {
   border: solid 1px #d8d8d8;
   border-right: none;
   padding-top: 3%;
   padding-left: 4%;
   min-height: 170px;
+  z-index: 2;
+  text-shadow: 1px 1px 2px #fff, -1px 1px 2px #fff, 1px -1px 2px #fff,
+    -1px -1px 2px #fff;
+  opacity: 0.9;
+  background-color: rgba(255, 255, 255, 0);
 }
 
 .Title {
@@ -290,11 +295,19 @@ body {
 }
 
 /* Chart Styles*/
+/* Note: .chart-box now has the settings that were previously used in bootstrap 'medium'
+   sizing, because we want to always show the overlapped chart/info view on the dashboard. */
 .chart-box {
   height: 170px;
   border: solid 1px #d8d8d8;
   padding-left: 0;
   padding-right: 0;
+  z-index: 1;
+  position: absolute;
+  left: 0px;
+  margin-left: -4px;
+  margin-right: -4px;
+  width: calc(6px + 100%);
 }
 
 .No-Data-Chart {
@@ -357,24 +370,7 @@ footer a {
 #div_detail {
   padding: "10px";
 }
-/* bootstrap md */
-@media only screen and (max-width: 991.98px) {
-  .chart-box {
-    z-index: 1;
-    position: absolute;
-    left: 0px;
-    margin-left: -4px;
-    margin-right: -4px;
-    width: calc(6px + 100%);
-  }
-  .box {
-    z-index: 2;
-    text-shadow: 1px 1px 2px #fff, -1px 1px 2px #fff, 1px -1px 2px #fff,
-      -1px -1px 2px #fff;
-    opacity: 0.9;
-    background-color: rgba(255, 255, 255, 0);
-  }
-}
+
 /* bootstrap sm */
 @media only screen and (max-width: 767.98px) {
   .container-fluid {

--- a/Websites/FloodzillaWeb/Views/Testing/Index.cshtml
+++ b/Websites/FloodzillaWeb/Views/Testing/Index.cshtml
@@ -77,6 +77,11 @@
               DANGER! Send all-clear (after flood) forecast to subscribed users
             </a>
           </li>
+          <li class="dropdown-item">
+            <a asp-controller="Testing" asp-action="SendForecastSmsTest" class="">
+              Forecast SMS Testing Page
+            </a>
+          </li>
         </ul>
       </div>
     </div>

--- a/Websites/FloodzillaWeb/Views/Testing/SendForecastSmsTest.cshtml
+++ b/Websites/FloodzillaWeb/Views/Testing/SendForecastSmsTest.cshtml
@@ -1,0 +1,42 @@
+@model FloodzillaWeb.Controllers.SmsForecastTestModel
+
+@{ 
+    Layout = "_AdminLayout";
+    ViewData["Title"] = "Send Forecast SMS Test";
+}
+
+<div class="row">
+    <div class="col-lg-12 col-md-12 col-xs-12 col-sm-12">
+        <div class="card card-info">
+          <div class="card-header">
+            <div class="card-title">Testing Tools</div>
+          </div>
+        </div>
+    </div>
+</div>
+
+<div class="row">
+  <div class="col-sm">
+    <div class="card">
+      <div class="card-header">Forecast SMS Testing</div>
+      <div class="card-body">
+        <div><span style="color: red; text-weight: bold;">@ViewBag.ForecastSmsTestError</span></div>
+        <div><span style="text-weight: bold;">@ViewBag.ForecastSmsTestResult</span></div>
+        <div>DANGER! Send a forecast SMS.  Forecast IDs must be found by database inspection...</div>
+        <div style="width:500px;">
+          <form asp-action="SendForecastSmsTest" method="post" class="form-horizontal" autocomplete="off">
+            <div>
+              <label asp-for="SmsTestNumber">Mobile Number to send SMS to:</label>
+              <input type="text" asp-for="SmsTestNumber" placeholder="9999999999">
+            </div>
+            <div>
+              <label asp-for="SmsTestForecastId">Forecast Id:</label>
+              <input type="text" asp-for="SmsTestForecastId" placeholder="e.g 10949">
+            </div>
+            <button type="submit" class="btn btn-primary">Send Test SMS</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div


### PR DESCRIPTION
added a page for testing forecast SMS.  converted the dashboard CSS/layout so that it always does the two-pane view in non-mobile mode.