### PR TITLE
return floodstage info with forecasts; show it on forecast page

### DIFF
--- a/Clients/react-fz-client/src/lib/forecastChartOptionsBuilder_highcharts.js
+++ b/Clients/react-fz-client/src/lib/forecastChartOptionsBuilder_highcharts.js
@@ -43,8 +43,8 @@ export default class ForecastChartOptionsBuilder {
     if (!isCombinedForecast) {
       return true;
     }
-    // Suppress Carnation for combined forecast
-    return (forecast.noaaForecast?.noaaSiteId !== "CRNW1");
+    // For the combined forecast, only show Falls.
+    return (forecast.noaaForecast?.noaaSiteId === "SQUW1");
   }
 
   setOptions(forecast) {

--- a/Libraries/FzCommon/Metagages.cs
+++ b/Libraries/FzCommon/Metagages.cs
@@ -1,5 +1,15 @@
 namespace FzCommon
 {
+    public class Metagage
+    {
+        public string Id;
+        public string SiteIds;
+        public string Name;
+        public string ShortName;
+        public double StageOne;
+        public double StageTwo;
+    }
+
     public class Metagages
     {
         //$ TODO: Support different regions
@@ -18,6 +28,38 @@ namespace FzCommon
                 if (MetagageIds[i] == gage)
                 {
                     return MetagageShortNames[i];
+                }
+            }
+            return null;
+        }
+
+        public static Metagage? FindMatchingMetagage(string[] subGageIds)
+        {
+            Array.Sort(subGageIds);
+            for (int i = 0; i < MetagageIds.Length; i++)
+            {
+                string[] metaIds = MetagageIds[i].Split("/");
+                Array.Sort(metaIds);
+                bool match = true;
+                for (int idIndex = 0; idIndex < subGageIds.Length; idIndex++)
+                {
+                    if (metaIds[idIndex] != subGageIds[idIndex])
+                    {
+                        match = false;
+                        break;
+                    }
+                }
+                if (match)
+                {
+                    return new Metagage()
+                    {
+                        Id = MetagageIds[i],
+                        SiteIds = MetagageSiteIds[i],
+                        Name = MetagageNames[i],
+                        ShortName = MetagageShortNames[i],
+                        StageOne = MetagageStageOnes[i],
+                        StageTwo = MetagageStageTwos[i],
+                    };
                 }
             }
             return null;

--- a/Services/ReadingSvc/ReadingStore.cs
+++ b/Services/ReadingSvc/ReadingStore.cs
@@ -70,6 +70,10 @@ namespace ReadingSvc
         public double PredictedFeetPerHour;
         public double PredictedCfsPerHour;
 
+        // Will only be set if forecasts are requested.
+        public double? DischargeStageOne;
+        public double? DischargeStageTwo;
+
         // Temporary, for debugging, to compare predictions to reality.
         public List<ApiGageReading> ActualReadings;
     }
@@ -141,6 +145,8 @@ namespace ReadingSvc
             DeviceBase device = null;
             UsgsSite usgsSite = null;
             NoaaForecast noaaForecast = null;
+            double? dischargeStageOne = null;
+            double? dischargeStageTwo = null;
             using (SqlConnection sqlcn = new SqlConnection(FzConfig.Config[FzConfig.Keys.SqlConnectionString]))
             {
                 sqlcn.Open();
@@ -181,6 +187,8 @@ namespace ReadingSvc
                                         item.Timestamp = region.ToRegionTimeFromUtc(item.Timestamp);
                                     }
                                 }
+                                dischargeStageOne = location.DischargeStageOne;
+                                dischargeStageTwo = location.DischargeStageTwo;
                             }
                         }
                     }
@@ -325,6 +333,8 @@ namespace ReadingSvc
                     PredictedFeetPerHour = feetPerHour,
                     PredictedCfsPerHour = cfsPerHour,
                     ActualReadings = actualReadings,
+                    DischargeStageOne = dischargeStageOne,
+                    DischargeStageTwo = dischargeStageTwo,
                 };
             }
         }


### PR DESCRIPTION
Add flood stage info to forecast data returned from ReadingSvc:
- if this is a multi-gage forecast request, go look for a matching Metagage and use its flood stage info
- if not, look in location.DischargeStageOne and DischargeStageTwo

If the floodstage info is present in a forecast, show it on the forecast page
- add a flood-stage line
- make sure the flood-level blue background is set appropriately
- scale the y-axis of the forecast chart to always have flood level in view