### PR TITLE
send forecast alerts via SMS

### DIFF
--- a/Data/SQL/Tables/Regions.sql
+++ b/Data/SQL/Tables/Regions.sql
@@ -18,6 +18,7 @@ CREATE TABLE [Regions](
 	[IsPublic] [bit] NOT NULL,
 	[OrganizationsId] [int] NOT NULL,
 	[BaseURL] [nvarchar](400) NULL,
+	[SmsFormatBaseURL] [nvarchar](400) NULL,
 	[TempADCTestsCount] [int] NULL,
 	[DefaultADCTestsCount] [int] NULL,
 	[TempADCTestsCountValidTill] [datetime] NULL,

--- a/Libraries/FzCommon/Processors/NoaaForecastProcessor.cs
+++ b/Libraries/FzCommon/Processors/NoaaForecastProcessor.cs
@@ -214,7 +214,7 @@ namespace FzCommon.Processors
                 await model.SendEmailToUserList(sqlcn,
                                                 FzConfig.Config[FzConfig.Keys.EmailFromAddress],
                                                 users,
-                                                false,
+                                                true,
                                                 sbResult,
                                                 sbDetails);
             }

--- a/Libraries/FzCommon/RegionBase.cs
+++ b/Libraries/FzCommon/RegionBase.cs
@@ -25,6 +25,8 @@ namespace FzCommon
         [Url(ErrorMessage = "Invalid URL.")]
         public string? BaseURL { get; set; }
 
+        public string? SmsFormatBaseURL { get; set; }
+
         public string? NotifyList { get; set; }
         public int? SensorOfflineThreshold { get; set; }
         public string? SlackNotifyUrl { get; set; }
@@ -142,7 +144,7 @@ namespace FzCommon
 
         private static string GetColumnList()
         {
-            return "RegionId, OrganizationsId, RegionName, Address, Latitude, Longitude, WindowsTimeZone, IanaTimeZone, BaseURL, "
+            return "RegionId, OrganizationsId, RegionName, Address, Latitude, Longitude, WindowsTimeZone, IanaTimeZone, BaseURL, SmsFormatBaseURL, "
                   +"IsActive, IsDeleted, IsPublic, NotifyList, SensorOfflineThreshold, SlackNotifyUrl";
         }
 
@@ -159,6 +161,7 @@ namespace FzCommon
                 WindowsTimeZone = SqlHelper.Read<string>(reader, "WindowsTimeZone"),
                 IanaTimeZone = SqlHelper.Read<string>(reader, "IanaTimeZone"),
                 BaseURL = SqlHelper.Read<string>(reader, "BaseURL"),
+                SmsFormatBaseURL = SqlHelper.Read<string>(reader, "SmsFormatBaseURL"),
                 IsActive = SqlHelper.Read<bool>(reader, "IsActive"),
                 IsDeleted = SqlHelper.Read<bool>(reader, "IsDeleted"),
                 IsPublic = SqlHelper.Read<bool>(reader, "IsPublic"),

--- a/Libraries/FzCommon/SmsClient.cs
+++ b/Libraries/FzCommon/SmsClient.cs
@@ -25,6 +25,7 @@ namespace FzCommon
         Success,
         InvalidNumber,
         Failure,
+        NotSending,
     }
 
     public class SmsClient
@@ -36,11 +37,16 @@ namespace FzCommon
         // email is only used for testing...
         public async Task<SmsSendResult> SendSms(string phone, string email, EmailModel model)
         {
+            string? smsText = model.GetSmsText();
+            if (String.IsNullOrEmpty(smsText))
+            {
+                return SmsSendResult.NotSending;
+            }
             SmsSendRequest req = new SmsSendRequest()
             {
                 Phone = phone,
                 Email = email,
-                SmsText = model.GetSmsText(),
+                SmsText = smsText,
             };
 
             string smsSendUrl = FzConfig.Config[FzConfig.Keys.SmsSendServiceUrl];

--- a/Websites/FloodzillaWeb/Controllers/AccountController.cs
+++ b/Websites/FloodzillaWeb/Controllers/AccountController.cs
@@ -680,6 +680,7 @@ namespace FloodzillaWeb.Controllers
                         case SmsSendResult.InvalidNumber:
                             return BadRequest("Invalid Phone Number.");
                         case SmsSendResult.Failure:
+                        case SmsSendResult.NotSending:
                             return StatusCode(500, "An error occurred while processing this request.");
                     }
                 }

--- a/Websites/FloodzillaWeb/Controllers/TestingController.cs
+++ b/Websites/FloodzillaWeb/Controllers/TestingController.cs
@@ -17,7 +17,7 @@ namespace FloodzillaWeb.Controllers
 {
     public class SmsForecastTestModel
     {
-        public string SmsTestNumber { get; set; }
+        public string? SmsTestNumber { get; set; }
         public int SmsTestForecastId { get; set; }
     }
 
@@ -361,14 +361,17 @@ namespace FloodzillaWeb.Controllers
                     // Assume that we didn't skip any IDs.  This is test code, it's fine.
                     NoaaForecastSet prev = await NoaaForecastSet.GetForecastSetForForecastId(sqlcn, minId - 1);
                     ForecastEmailModel emailModel = await NoaaForecastProcessor.BuildEmailModel(sqlcn, current, prev);
-                    emailModel.GetSmsText();
-                    SmsClient client = new SmsClient();
-                    SmsSendResult result = await client.SendSms(model.SmsTestNumber, "test@floodzilla.com", emailModel);
-                    if (result != SmsSendResult.Success) 
+                    ViewBag.ForecastSmsText = emailModel.GetSmsText();
+                    if (model.SmsTestNumber != null)
                     {
-                        throw new ApplicationException("Result: " + result.ToString());
+                        SmsClient client = new SmsClient();
+                        SmsSendResult result = await client.SendSms(model.SmsTestNumber, "test@floodzilla.com", emailModel);
+                        if (result != SmsSendResult.Success)
+                        {
+                            throw new ApplicationException("Result: " + result.ToString());
+                        }
+                        ViewBag.ForecastSmsTestResult = "Sent SMS to " + model.SmsTestNumber;
                     }
-                    ViewBag.ForecastSmsTestResult = "Sent SMS";
                 }                
             }
             catch (Exception e)

--- a/Websites/FloodzillaWeb/Views/Regions/Create.cshtml
+++ b/Websites/FloodzillaWeb/Views/Regions/Create.cshtml
@@ -64,6 +64,16 @@
     </div>
   </div>
 
+  <div class="form-group row">
+    <div class="col-md-2 control-label">
+      <label asp-for="SmsFormatBaseURL" class="control-label">SMS Format Base URL:</label>
+    </div>
+    <div class="col-md-10">
+      <input type="text" asp-for="SmsFormatBaseURL" class="form-control" />
+      <span asp-validation-for="SmsFormatBaseURL" class="text-danger" />
+    </div>
+  </div>
+
   <hr />
 
   <h6>Monitoring</h6>

--- a/Websites/FloodzillaWeb/Views/Regions/Edit.cshtml
+++ b/Websites/FloodzillaWeb/Views/Regions/Edit.cshtml
@@ -67,6 +67,16 @@
     </div>
   </div>
 
+  <div class="form-group row">
+    <div class="col-md-2 control-label">
+      <label asp-for="SmsFormatBaseURL" class="control-label">SMS Format Base URL:</label>
+    </div>
+    <div class="col-md-10">
+      <input type="text" asp-for="SmsFormatBaseURL" class="form-control" />
+      <span asp-validation-for="SmsFormatBaseURL" class="text-danger" />
+    </div>
+  </div>
+
   <hr />
 
   <h6>Monitoring</h6>

--- a/Websites/FloodzillaWeb/Views/Testing/SendForecastSmsTest.cshtml
+++ b/Websites/FloodzillaWeb/Views/Testing/SendForecastSmsTest.cshtml
@@ -22,15 +22,23 @@
       <div class="card-body">
         <div><span style="color: red; text-weight: bold;">@ViewBag.ForecastSmsTestError</span></div>
         <div><span style="text-weight: bold;">@ViewBag.ForecastSmsTestResult</span></div>
-        <div>DANGER! Send a forecast SMS.  Forecast IDs must be found by database inspection...</div>
+        @if (!String.IsNullOrEmpty(ViewBag.ForecastSmsText))
+        {
+        <div>
+          <span>SMS Text:</span>
+          <div style="width: 500px; background-color: #e3e3e3; margin-left: 25px;"><pre>@ViewBag.ForecastSmsText</pre></div>
+        </div>
+        }
+        <div>Send a forecast SMS.  Forecast IDs must be found by database inspection...</div>
+        <br />
         <div style="width:500px;">
           <form asp-action="SendForecastSmsTest" method="post" class="form-horizontal" autocomplete="off">
             <div>
-              <label asp-for="SmsTestNumber">Mobile Number to send SMS to:</label>
+              <label asp-for="SmsTestNumber">Mobile Number to send SMS to (leave blank to just see SMS text):</label>
               <input type="text" asp-for="SmsTestNumber" placeholder="9999999999">
             </div>
             <div>
-              <label asp-for="SmsTestForecastId">Forecast Id:</label>
+              <label asp-for="SmsTestForecastId">Forecast Id (10949 has a flood, 10973 is an all-clear):</label>
               <input type="text" asp-for="SmsTestForecastId" placeholder="e.g 10949">
             </div>
             <button type="submit" class="btn btn-primary">Send Test SMS</button>


### PR DESCRIPTION
Support sending forecast alerts via SMS:
- add a 'SmsFormatBaseURL' field to Region (e.g. "floodzilla.com" vs "https://floodzilla.com/")
- rewrite slack forecast format to support new SMS format
- make forecast fetcher send SMS if appropriate
- make sms-forecast-test page just show the SMS text if you don't give a phone number to test with
