### PR TITLE
allow node_modules to be published

### DIFF
--- a/Websites/FloodzillaWeb/FloodzillaWeb.csproj
+++ b/Websites/FloodzillaWeb/FloodzillaWeb.csproj
@@ -6,6 +6,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DefaultItemExcludes>$([System.String]::Copy($(DefaultItemExcludes)).Replace(';**\node_modules\**',''))</DefaultItemExcludes>
+    <DefaultItemExcludes>$([System.String]::Copy($(DefaultItemExcludes)).Replace(';node_modules\**',''))</DefaultItemExcludes>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Remove="developer.settings.json" />
   </ItemGroup>


### PR DESCRIPTION
this is so ugly.  by default, vstudio ignores node_modules, so we add an override for a default property to remove the node_modules exclusion.   fragile.  sucks.
