### PR TITLE
add a controller just to serve the single file "/.well-known/apple-a…

### DIFF
--- a/Websites/FloodzillaWeb/Controllers/AppleEndpointController.cs
+++ b/Websites/FloodzillaWeb/Controllers/AppleEndpointController.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+
+using FzCommon;
+
+namespace FloodzillaWeb.Controllers
+{
+
+    public class AppleEndpointController : Controller
+    {
+        [Route(".well-known/apple-app-site-association")]
+        public IActionResult AppleAppSiteAssociation()
+        {
+            return File("/.well-known/apple-app-site-association.json", "application/json");
+        }
+    }
+
+}
+


### PR DESCRIPTION
ugly.  we now explicitly serve the apple this-site-corresponds-to-this-app file using its "correct" extensionless name.  note that in order for this to work, it has to be copied into the wwwroot\.well-known directory with a .json extension.
