### PR TITLE
support utcmsec as a valid format for "time" field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,5 @@ MigrationBackup/
 .ionide/
 .vscode/settings.json
 launchSettings.json
+Services/SenixListener/Properties/ServiceDependencies/SenixListener - Web Deploy/appInsights1.arm.json
+Services/SenixListener/Properties/ServiceDependencies/SenixListener - Web Deploy/storage1.arm.json

--- a/Services/SenixListener/Properties/serviceDependencies.SenixListener - Web Deploy.json
+++ b/Services/SenixListener/Properties/serviceDependencies.SenixListener - Web Deploy.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "resourceId": "/subscriptions/[parameters('subscriptionId')]/resourceGroups/[parameters('resourceGroupName')]/providers/microsoft.insights/components/SenixListener",
+      "type": "appInsights.azure",
+      "connectionId": "APPINSIGHTS_INSTRUMENTATIONKEY"
+    },
+    "storage1": {
+      "resourceId": "/subscriptions/[parameters('subscriptionId')]/resourceGroups/[parameters('resourceGroupName')]/providers/Microsoft.Storage/storageAccounts/svpastorage",
+      "type": "storage.azure",
+      "connectionId": "AzureWebJobsStorage"
+    }
+  }
+}

--- a/Services/SenixListener/Properties/serviceDependencies.json
+++ b/Services/SenixListener/Properties/serviceDependencies.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "appInsights1": {
-      "type": "appInsights"
+      "type": "appInsights",
+      "connectionId": "APPINSIGHTS_INSTRUMENTATIONKEY"
     },
     "storage1": {
       "type": "storage",


### PR DESCRIPTION
New firmware on one of our Senix receivers means that we are now getting UTC msec as a format for the "time" field.  So we now support parsing that.  Also added a noisy fallback if the "time" field is unparseable.