### PR TITLE
filter out non-public gauges

### DIFF
--- a/Services/ReadingSvc/ReadingSvc.cs
+++ b/Services/ReadingSvc/ReadingSvc.cs
@@ -136,6 +136,10 @@ namespace ReadingSvc
                 };
                 foreach (SensorLocationBase location in locations)
                 {
+                    if (!location.IsPublic)
+                    {
+                        continue;
+                    }
                     if (!allReadings.ContainsKey(location.Id))
                     {
                         continue;


### PR DESCRIPTION
If a non-public gauge had a non-deleted reading, it would be returned in the output of GetGageStatusAndRecentReadings (and, incidentally, be malformed, with missing metadata).  We now correctly suppress non-public gauges.