### PR TITLE
make 'contact info' on locations a textarea

### DIFF
--- a/Websites/FloodzillaWeb/Views/Locations/Create.cshtml
+++ b/Websites/FloodzillaWeb/Views/Locations/Create.cshtml
@@ -113,7 +113,7 @@
       
       <div class="form-group">
         <label class="control-label-left">Land owner contact info:<span class="control-desc-inline">&nbsp;(internal)</span></label>
-        <input type="text" asp-for="ContactInfo" class="form-control" placeholder="Contact Info" />
+        <textarea asp-for="ContactInfo" class="form-control" cols="5" rows="2" placeholder="Contact Info"></textarea>
         <span asp-validation-for="ContactInfo" class="text-danger"></span>
       </div>
 

--- a/Websites/FloodzillaWeb/Views/Locations/Edit.cshtml
+++ b/Websites/FloodzillaWeb/Views/Locations/Edit.cshtml
@@ -128,7 +128,7 @@
       
       <div class="form-group">
         <label class="control-label-left">Land owner contact info:<span class="control-desc-inline">&nbsp;(internal)</span></label>
-        <input type="text" asp-for="ContactInfo" class="form-control" placeholder="Contact Info" />
+        <textarea asp-for="ContactInfo" class="form-control" cols="5" rows="2" placeholder="Contact Info"></textarea>
         <span asp-validation-for="ContactInfo" class="text-danger"></span>
       </div>
 


### PR DESCRIPTION
per admin request - make contact info field on edit/create location pages a textarea instead of a text field