### PR TITLE
USGS: sometimes there are more discharge readings than height readings

### DIFF
--- a/Libraries/FzCommon/UsgsSite.cs
+++ b/Libraries/FzCommon/UsgsSite.cs
@@ -179,7 +179,7 @@ namespace FzCommon
                         {
 #if DISCARD_MISMATCHED_READINGS
                             int i = 0;
-                            while (i < dischargeSeries.Values[0].Value.Count)
+                            while (i < dischargeSeries.Values[0].Value.Count && i < waterHeightSeries.Values[0].Value.Count)
                             {
                                 if (dischargeSeries.Values[0].Value[i].DateTime.Ticks != waterHeightSeries.Values[0].Value[i].DateTime.Ticks)
                                 {
@@ -193,6 +193,10 @@ namespace FzCommon
                             while (i < waterHeightSeries.Values[0].Value.Count)
                             {
                                 waterHeightSeries.Values[0].Value.RemoveAt(i);
+                            }
+                            while (i < dischargeSeries.Values[0].Value.Count)
+                            {
+                                dischargeSeries.Values[0].Value.RemoveAt(i);
                             }
                         }
                         else


### PR DESCRIPTION
Sometimes the USGS systems return a different number of discharge readings vs water height readings.  We had code to handle the mismatches but the code assumed there were always more height readings than discharge (because that's usually how they were coming in mismatched).  Today there was a USGS outage, and when the data came back, it temporarily came back with more discharge than height data, which was causing a crash.

We now handle that case correctly.