### PR TITLE
add 'org admin' to roles on GetUsers()

### DIFF
--- a/Websites/FloodzillaWeb/Controllers/UsersController.cs
+++ b/Websites/FloodzillaWeb/Controllers/UsersController.cs
@@ -343,7 +343,7 @@ namespace FloodzillaWeb.Controllers
             return RedirectToAction("Index");
         }
 
-        [Authorize(Roles = "Admin")]
+        [Authorize(Roles = "Admin,Organization Admin")]
         public IActionResult GetUsers(bool showDeleted)
         {
             return Ok(JsonConvert.SerializeObject(new { Data = GetUserList(showDeleted) }));


### PR DESCRIPTION
org admins should be able to use the admin "users" page