### PR TITLE
allow caching of static files (but preserve nocache for the client SPA hopefully)

### DIFF
--- a/Websites/FloodzillaWeb/Startup.cs
+++ b/Websites/FloodzillaWeb/Startup.cs
@@ -60,6 +60,8 @@ namespace FloodzillaWeb
             services.AddControllersWithViews(o => o.SuppressImplicitRequiredAttributeForNonNullableReferenceTypes = true)
                     .AddNewtonsoftJson();
 
+            services.AddResponseCaching();
+
             services.AddScoped<IdentityUser, ApplicationUser>();
             services.AddScoped<UserPermissions>();
 
@@ -144,6 +146,7 @@ namespace FloodzillaWeb
                            .AllowAnyOrigin()
                            .AllowAnyMethod()
                            .AllowAnyHeader());
+            app.UseResponseCaching();
 
             app.UseDefaultFiles();
             FileExtensionContentTypeProvider ctp = new();

--- a/Websites/FloodzillaWeb/web.config
+++ b/Websites/FloodzillaWeb/web.config
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<system.webServer>
-		<httpProtocol>
-			<customHeaders>
-				<add name="Cache-Control" value="no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0, s-maxage=0" />
-				<add name="Pragma" value="no-cache" />
-				<add name="Expires" value="0" />
-			</customHeaders>
-		</httpProtocol>
 		<rewrite>
 			<rules>
 				<clear />


### PR DESCRIPTION
(a) remove some cruft from web.config that I had put in as an attempt to force no-cache for the client SPA index.html
(b) add 'response caching' middleware to allow caching of other static files served by the site