### PR TITLE
use FETCH NEXT instead of ROWCOUNT with paged queries

### DIFF
--- a/Data/SQL/Procs/GetAllSensorReadingsForDevice.sql
+++ b/Data/SQL/Procs/GetAllSensorReadingsForDevice.sql
@@ -21,13 +21,21 @@ BEGIN
 	END
 
 	IF @readingCount IS NOT NULL
-		SET ROWCOUNT @readingcount
-	SELECT * from SensorReadings
-		WHERE DeviceId = @deviceId
-		AND (@fromTime IS NULL OR Timestamp >= @fromTime)
-		AND (@toTime IS NULL OR Timestamp <= @toTime)
-		ORDER BY Timestamp DESC
-		OFFSET (@skipCount) ROWS
-	SET ROWCOUNT 0
+
+        SELECT * from SensorReadings
+            WHERE DeviceId = @deviceId
+            AND (@fromTime IS NULL OR Timestamp >= @fromTime)
+            AND (@toTime IS NULL OR Timestamp <= @toTime)
+            ORDER BY Timestamp DESC
+            OFFSET (@skipCount) ROWS
+            FETCH NEXT @readingCount ROWS ONLY
+    ELSE
+        SELECT * from SensorReadings
+            WHERE DeviceId = @deviceId
+            AND (@fromTime IS NULL OR Timestamp >= @fromTime)
+            AND (@toTime IS NULL OR Timestamp <= @toTime)
+            ORDER BY Timestamp DESC
+            OFFSET (@skipCount) ROWS
+
 END
 GO

--- a/Data/SQL/Procs/GetAllSensorReadingsForLocation.sql
+++ b/Data/SQL/Procs/GetAllSensorReadingsForLocation.sql
@@ -21,13 +21,19 @@ BEGIN
 	END
 
 	IF @readingCount IS NOT NULL
-		SET ROWCOUNT @readingcount
-	SELECT * from SensorReadings
-		WHERE LocationId = @locationId
-		AND (@fromTime IS NULL OR Timestamp >= @fromTime)
-		AND (@toTime IS NULL OR Timestamp <= @toTime)
-		ORDER BY Timestamp DESC
-		OFFSET (@skipCount) ROWS
-	SET ROWCOUNT 0
+        SELECT * from SensorReadings
+            WHERE LocationId = @locationId
+            AND (@fromTime IS NULL OR Timestamp >= @fromTime)
+            AND (@toTime IS NULL OR Timestamp <= @toTime)
+            ORDER BY Timestamp DESC
+            OFFSET (@skipCount) ROWS
+            FETCH NEXT @readingCount ROWS ONLY
+    ELSE
+        SELECT * from SensorReadings
+            WHERE LocationId = @locationId
+            AND (@fromTime IS NULL OR Timestamp >= @fromTime)
+            AND (@toTime IS NULL OR Timestamp <= @toTime)
+            ORDER BY Timestamp DESC
+            OFFSET (@skipCount) ROWS
 END
 GO

--- a/Data/SQL/Procs/GetAllSensorReadingsForLocationNoSkip.sql
+++ b/Data/SQL/Procs/GetAllSensorReadingsForLocationNoSkip.sql
@@ -19,12 +19,18 @@ BEGIN
 	END
 
 	IF @readingCount IS NOT NULL
-		SET ROWCOUNT @readingcount
-	SELECT * from SensorReadings
-		WHERE LocationId = @locationId
-		AND (@fromTime IS NULL OR Timestamp >= @fromTime)
-		AND (@toTime IS NULL OR Timestamp <= @toTime)
-		ORDER BY Timestamp DESC
-	SET ROWCOUNT 0
+        SELECT * from SensorReadings
+            WHERE LocationId = @locationId
+            AND (@fromTime IS NULL OR Timestamp >= @fromTime)
+            AND (@toTime IS NULL OR Timestamp <= @toTime)
+            ORDER BY Timestamp DESC
+            OFFSET (0) ROWS
+            FETCH NEXT @readingCount ROWS ONLY
+    ELSE
+        SELECT * from SensorReadings
+            WHERE LocationId = @locationId
+            AND (@fromTime IS NULL OR Timestamp >= @fromTime)
+            AND (@toTime IS NULL OR Timestamp <= @toTime)
+            ORDER BY Timestamp DESC
 END
 GO


### PR DESCRIPTION
fix some sql timeout issues by using FETCH NEXT instead of ROWCOUNT to limit result sets in paged queries