### PR TITLE
allow jobs to save their details for debugging

### DIFF
--- a/Data/SQL/Procs/GetAllSensorReadingsForDevice.sql
+++ b/Data/SQL/Procs/GetAllSensorReadingsForDevice.sql
@@ -20,7 +20,7 @@ BEGIN
 		SELECT @fromTime = Timestamp FROM SensorReadings WHERE Id = @lastReadingId
 	END
 
-	IF @readingCount IS NOT NULL
+	IF @readingCount IS NOT NULL AND @readingCount > 0
 
         SELECT * from SensorReadings
             WHERE DeviceId = @deviceId

--- a/Data/SQL/Procs/GetAllSensorReadingsForLocation.sql
+++ b/Data/SQL/Procs/GetAllSensorReadingsForLocation.sql
@@ -20,7 +20,7 @@ BEGIN
 		SELECT @fromTime = Timestamp FROM SensorReadings WHERE Id = @lastReadingId
 	END
 
-	IF @readingCount IS NOT NULL
+	IF @readingCount IS NOT NULL AND @readingCount > 0
         SELECT * from SensorReadings
             WHERE LocationId = @locationId
             AND (@fromTime IS NULL OR Timestamp >= @fromTime)

--- a/Data/SQL/Procs/GetAllSensorReadingsForLocationNoSkip.sql
+++ b/Data/SQL/Procs/GetAllSensorReadingsForLocationNoSkip.sql
@@ -18,7 +18,7 @@ BEGIN
 		SELECT @fromTime = Timestamp FROM SensorReadings WHERE Id = @lastReadingId
 	END
 
-	IF @readingCount IS NOT NULL
+	IF @readingCount IS NOT NULL AND @readingCount > 0
         SELECT * from SensorReadings
             WHERE LocationId = @locationId
             AND (@fromTime IS NULL OR Timestamp >= @fromTime)

--- a/Data/SQL/Procs/GetRecentJobRunLogsWithDetails.sql
+++ b/Data/SQL/Procs/GetRecentJobRunLogsWithDetails.sql
@@ -1,0 +1,16 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE PROCEDURE [GetRecentJobRunLogsWithDetails]
+	@startTime DateTime
+AS
+BEGIN
+
+    SELECT * from JobRunLogs
+        WHERE StartTime >= @startTime
+        AND Details IS NOT NULL
+        ORDER BY StartTime DESC
+END
+GO

--- a/Data/SQL/Procs/SaveJob.sql
+++ b/Data/SQL/Procs/SaveJob.sql
@@ -15,7 +15,8 @@ CREATE PROCEDURE [SaveJob]
     @LastFullException TEXT = NULL,
     @DisableReason NVARCHAR(200) = NULL,
     @DisabledTime DATETIME = NULL,
-    @DisabledBy NVARCHAR(200) = NULL
+    @DisabledBy NVARCHAR(200) = NULL,
+    @ShouldSaveDetails BIT = 0
 )
 AS
 BEGIN
@@ -34,7 +35,8 @@ BEGIN
     LastFullException = @LastFullException,
     DisableReason = @DisableReason,
     DisabledTime = @DisabledTime,
-    DisabledBy = @DisabledBy
+    DisabledBy = @DisabledBy,
+    ShouldSaveDetails = @ShouldSaveDetails
   WHERE
     Id = @Id
 END

--- a/Data/SQL/Procs/SaveJobRunLog.sql
+++ b/Data/SQL/Procs/SaveJobRunLog.sql
@@ -10,7 +10,8 @@ CREATE PROCEDURE [SaveJobRunLog]
 	@EndTime datetime,
 	@Summary nvarchar(500) = null,
 	@Exception nvarchar(200) = null,
-	@FullException text = null
+	@FullException text = null,
+    @Details text = null
 AS
 BEGIN
   DECLARE @Id int
@@ -20,9 +21,9 @@ BEGIN
     INSERT INTO JobNames (JobName) VALUES (@JobName)
   END
 
-	INSERT INTO JobRunLogs (JobName, MachineName, StartTime, EndTime, Summary, Exception, FullException)
-   	VALUES (@JobName, @MachineName, @StartTime, @EndTime, @Summary, @Exception, @FullException)
-	END
+  INSERT INTO JobRunLogs (JobName, MachineName, StartTime, EndTime, Summary, Exception, FullException, Details)
+    VALUES (@JobName, @MachineName, @StartTime, @EndTime, @Summary, @Exception, @FullException, @Details)
+  END
 
   SELECT * FROM JobRunLogs WHERE Id=@@IDENTITY
 GO

--- a/Data/SQL/Tables/JobRunLogs.sql
+++ b/Data/SQL/Tables/JobRunLogs.sql
@@ -10,6 +10,7 @@ CREATE TABLE [JobRunLogs](
 	[StartTime] [datetime] NOT NULL,
 	[EndTime] [datetime] NOT NULL,
 	[Summary] [nvarchar](500) NULL,
+    [Details] [text] NULL,
 	[Exception] [nvarchar](200) NULL,
 	[FullException] [text] NULL,
 PRIMARY KEY CLUSTERED 

--- a/Data/SQL/Tables/Jobs.sql
+++ b/Data/SQL/Tables/Jobs.sql
@@ -19,6 +19,7 @@ CREATE TABLE [dbo].[Jobs](
 	[LastError] [nvarchar](200) NULL,
 	[LastFullException] [text] NULL,
 	[IsEnabled] [bit] NOT NULL,
+    [ShouldSaveDetails] [bit] NOT NULL,
 	[DisableReason] [nvarchar](200) NULL,
 	[DisabledTime] [datetime] NULL,
 	[DisabledBy] [nvarchar](200) NULL,
@@ -30,6 +31,9 @@ PRIMARY KEY CLUSTERED
 GO
 
 ALTER TABLE [dbo].[Jobs] ADD  CONSTRAINT [Jobs_DefaultIsEnabled]  DEFAULT ((1)) FOR [IsEnabled]
+GO
+
+ALTER TABLE [dbo].[Jobs] ADD  CONSTRAINT [Jobs_DefaultShouldSaveDetails]  DEFAULT ((0)) FOR [ShouldSaveDetails]
 GO
 
 CREATE UNIQUE NONCLUSTERED INDEX [IX_Job_JobName] ON [dbo].[Jobs]

--- a/Libraries/FzCommon/Fetchers/USGSWdfnFetcher.cs
+++ b/Libraries/FzCommon/Fetchers/USGSWdfnFetcher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -217,20 +217,59 @@ namespace FzCommon.Fetchers
             // This is a shortcut -- if our latest discharge reading and our latest height reading are the same
             // (which should be the common case, if we're updating a gauge that has been receiving data), we don't
             // need to go back and fetch any old data, we can just start with the reading we've got.
+            if (latestDischarge == null)
+            {
+                updStat.sbDetails.AppendFormat("-- Device {0}: No latest discharge reading\r\n", device.DeviceId);
+            }
+            else
+            {
+                updStat.sbDetails.AppendFormat("-- Device {0}: Latest discharge reading [{1}], {2} ft / {3} cfs @ {4}\r\n",
+                                               device.DeviceId,
+                                               latestDischarge.Id,
+                                               latestDischarge.WaterHeightFeet,
+                                               latestDischarge.WaterDischarge,
+                                               latestDischarge.Timestamp);
+            }
+            if (latestHeight == null)
+            {
+                updStat.sbDetails.AppendFormat("-- Device {0}: No latest height reading\r\n", device.DeviceId);
+            }
+            else
+            {
+                updStat.sbDetails.AppendFormat("-- Device {0}: Latest height reading [{1}], {2} ft / {3} cfs @ {4}\r\n",
+                                               device.DeviceId,
+                                               latestHeight.Id,
+                                               latestHeight.WaterHeightFeet,
+                                               latestHeight.WaterHeight,
+                                               latestHeight.Timestamp);
+            }
             if (latestDischarge != null && latestHeight != null && latestDischarge.Timestamp == latestHeight.Timestamp)
             {
                 if (latestDischarge.Id != latestHeight.Id)
                 {
                     ErrorManager.ReportError(ErrorSeverity.Major,
-                                             "FloodzillaJobs.UsgsDataFetcher",
+                                             "FloodzillaJobs.USGSWdfnFetcher",
                                              String.Format("Duplicate reading for location {0}, timestamp {1}: {2} != {3}", location.Id, latestDischarge.Timestamp, latestDischarge.Id, latestHeight.Id));
+                    updStat.sbDetails.AppendFormat("!! Device {0}: duplicate reading @ {1}: {2} != {3}\r\n", device.DeviceId, latestDischarge.Timestamp, latestDischarge.Id, latestHeight.Id);
                 }
                 availableReadings.Add(latestHeight);
+                updStat.sbDetails.AppendFormat("Device {0}: Loaded existing latest reading [{1}] {2} ft, {3} cfs @ {4}\r\n",
+                                               device.DeviceId,
+                                               latestHeight.Id,
+                                               latestHeight.WaterHeightFeet,
+                                               latestHeight.WaterDischarge,
+                                               latestHeight.Timestamp);
             }
             else
             {
                 // We need to make sure we've loaded every relevant reading.
+                updStat.sbDetails.AppendFormat("-- Device {0}: Loading all readings for location {1} from {2} until now\r\n", device.DeviceId, location.Id, startTime);
                 availableReadings = await SensorReading.GetAllReadingsForLocation(location.Id, 0, startTime, DateTime.UtcNow);
+                updStat.sbDetails.AppendFormat("Device {0}: Loaded {1} readings (first 10 shown)\r\n", device.DeviceId, availableReadings.Count);
+                for (int i = 0; i < 10 && i < availableReadings.Count; i++)
+                {
+                    updStat.sbDetails.AppendFormat("  [{0}]: {1} ft, {2} cfs @ {3}\r\n", availableReadings[i].Id, availableReadings[i].WaterHeightFeet, availableReadings[i].WaterDischarge, availableReadings[i].Timestamp);
+                }
             }
             await FetchAndUpdateGaugeData(sqlcn,
                                           usgsSite,
@@ -267,7 +306,7 @@ namespace FzCommon.Fetchers
             }
             else
             {
-                dischargeReadings = await usgsSite.FetchRawWdfnReadings(startTimeUtc, endTimeUtc, device, WdfnReadingType.Discharge);;
+                dischargeReadings = await usgsSite.FetchRawWdfnReadings(startTimeUtc, endTimeUtc, device, WdfnReadingType.Discharge); ;
             }
             if (dischargeReadings != null)
             {
@@ -285,6 +324,15 @@ namespace FzCommon.Fetchers
                 // No news is good news.
                 updStat.sbDetails.AppendFormat("Device {0}: No new USGS data available", device.DeviceId);
                 return;
+            }
+
+            foreach (WdfnReading dr in dischargeReadings)
+            {
+                updStat.sbDetails.AppendFormat("-- Device {0}: READING: Discharge: {1} @ {2}\r\n", device.DeviceId, dr.Value, dr.Timestamp);
+            }
+            foreach (WdfnReading hr in heightReadings)
+            {
+                updStat.sbDetails.AppendFormat("-- Device {0}: READING: Height: {1} @ {2}\r\n", device.DeviceId, hr.Value, hr.Timestamp);
             }
 
             // Keep track of which, if any, of our already-loaded readings will have to be saved.
@@ -317,13 +365,19 @@ namespace FzCommon.Fetchers
                                                : "Filtered (invalid water height)";
                     }
                     await availableReadings[i].Save(sqlcn);
+                    updStat.sbDetails.AppendFormat("++ Device {0}: Saved reading [{1}] {2} ft / {3} cfs @ {4}\r\n",
+                                                   device.DeviceId,
+                                                   availableReadings[i].Id,
+                                                   availableReadings[i].WaterHeightFeet,
+                                                   availableReadings[i].WaterDischarge,
+                                                   availableReadings[i].Timestamp);
                 }
             }
-            updStat.sbDetails.AppendFormat("Device {0}: {1} new height readings, {2} new discharge readings\n",
+            updStat.sbDetails.AppendFormat("Device {0}: {1} new height readings, {2} new discharge readings\r\n",
                                            device.DeviceId,
                                            subStat.heightReadingCount,
                                            subStat.dischargeReadingCount);
-            updStat.sbSummary.AppendFormat("Device {0}: {1} new height readings, {2} new discharge readings\n",
+            updStat.sbSummary.AppendFormat("Device {0}: {1} new height readings, {2} new discharge readings\r\n",
                                            device.DeviceId,
                                            subStat.heightReadingCount,
                                            subStat.dischargeReadingCount);
@@ -402,12 +456,13 @@ namespace FzCommon.Fetchers
                 // separately...
                 if (!reading.WaterHeight.HasValue)
                 {
-                    updStat.sbDetails.AppendFormat("Device {0}: Received height reading of {1} at {2}\n", device.DeviceId, newWaterHeightFeet.Value, reading.Timestamp);
+                    updStat.sbDetails.AppendFormat("Device {0}: Received height reading [{1}] of {2} at {3}\n", device.DeviceId, reading.Id, newWaterHeightFeet.Value, reading.Timestamp);
                 }
                 else if (reading.WaterHeight.Value != waterHeightInches)
                 {
-                    updStat.sbDetails.AppendFormat("Device {0}: Updating height reading from {1} to {2} at {3}\n",
+                    updStat.sbDetails.AppendFormat("Device {0}: Updating height reading [{1}] from {2} to {3} at {4}\n",
                                                    device.DeviceId,
+                                                   reading.Id,
                                                    reading.WaterHeight.Value,
                                                    newWaterHeightFeet.Value,
                                                    reading.Timestamp);
@@ -454,12 +509,13 @@ namespace FzCommon.Fetchers
                 // separately...
                 if (!reading.WaterDischarge.HasValue)
                 {
-                    updStat.sbDetails.AppendFormat("Device {0}: Received discharge reading of {1} at {2}\n", device.DeviceId, newDischarge.Value, reading.Timestamp);
+                    updStat.sbDetails.AppendFormat("Device {0}: Received discharge reading [{1}] of {2} at {3}\n", device.DeviceId, reading.Id, newDischarge.Value, reading.Timestamp);
                 }
                 else if (reading.WaterDischarge.Value != newDischarge.Value)
                 {
-                    updStat.sbDetails.AppendFormat("Device {0}: Updating discharge reading from {1} to {2} at {3}\n",
+                    updStat.sbDetails.AppendFormat("Device {0}: Updating discharge reading [{1}] from {2} to {3} at {4}\n",
                                                    device.DeviceId,
+                                                   reading.Id,
                                                    reading.WaterDischarge.Value,
                                                    newDischarge.Value,
                                                    reading.Timestamp);

--- a/Libraries/FzCommon/JobEntry.cs
+++ b/Libraries/FzCommon/JobEntry.cs
@@ -53,6 +53,7 @@ namespace FzCommon
         public string? LastError                { get; set; }
         public string? LastFullException        { get; set; }
         public bool IsEnabled                   { get; set; }
+        public bool ShouldSaveDetails           { get; set; }
         public string? DisableReason            { get; set; }
         public DateTime? DisabledTime           { get; set; }
         public string? DisabledBy               { get; set; }
@@ -150,7 +151,7 @@ namespace FzCommon
             return true;
         }
 
-        public void ReportJobSuccess(SqlConnection sqlcn, string summary)
+        public void ReportJobSuccess(SqlConnection sqlcn, string summary, string details)
         {
             if (this.m_currentRun == null)
             {
@@ -158,6 +159,10 @@ namespace FzCommon
             }
             this.LastEndTime = DateTime.UtcNow;
             m_currentRun.Summary = summary;
+            if (this.ShouldSaveDetails)
+            {
+                m_currentRun.Details = details;
+            }
             RecentJobRun jobRun = this.m_currentRun.ReportJobRunSuccess(sqlcn, this.LastEndTime.Value);
             this.LastRunLogId = jobRun.Id;
             this.m_currentRun = null;
@@ -169,13 +174,17 @@ namespace FzCommon
             this.Save(sqlcn);
         }
 
-        public void ReportJobException(SqlConnection sqlcn, Exception ex)
+        public void ReportJobException(SqlConnection sqlcn, string details, Exception ex)
         {
             if (this.m_currentRun == null)
             {
                 throw new ApplicationException("ReportJobException requires StartJobRun to be called first");
             }
             this.LastEndTime = DateTime.UtcNow;
+            if (this.ShouldSaveDetails)
+            {
+                m_currentRun.Details = details;
+            }
             RecentJobRun jobRun = this.m_currentRun.ReportJobRunException(sqlcn, ex, this.LastEndTime.Value);
             this.LastRunLogId = jobRun.Id;
             this.m_currentRun = null;
@@ -219,6 +228,7 @@ namespace FzCommon
             cmd.Parameters.AddWithValue("@JobName", this.JobName);
             cmd.Parameters.AddWithValue("@FriendlyName", this.FriendlyName);
             cmd.Parameters.AddWithValue("@IsEnabled", this.IsEnabled);
+            cmd.Parameters.AddWithValue("@ShouldSaveDetails", this.ShouldSaveDetails);
             SqlHelper.AddParamIfNotEmpty<DateTime?>(cmd.Parameters, "@LastStartTime", this.LastStartTime);
             SqlHelper.AddParamIfNotEmpty<DateTime?>(cmd.Parameters, "@LastEndTime", this.LastEndTime);
             SqlHelper.AddParamIfNotEmpty<DateTime?>(cmd.Parameters, "@LastSuccessfulEndTime", this.LastSuccessfulEndTime);
@@ -250,6 +260,7 @@ namespace FzCommon
                 LastError = SqlHelper.Read<string?>(reader, "LastError"),
                 LastFullException = SqlHelper.Read<string?>(reader, "LastFullException"),
                 IsEnabled = SqlHelper.Read<bool>(reader, "IsEnabled"),
+                ShouldSaveDetails = SqlHelper.Read<bool>(reader, "ShouldSaveDetails"),
                 DisableReason = SqlHelper.Read<string?>(reader, "DisableReason"),
                 DisabledTime = SqlHelper.Read<DateTime?>(reader, "DisabledTime"),
                 DisabledBy = SqlHelper.Read<string?>(reader, "DisabledBy"),

--- a/Libraries/FzCommon/JobRunLog.cs
+++ b/Libraries/FzCommon/JobRunLog.cs
@@ -12,6 +12,7 @@ namespace FzCommon
         public DateTime StartTime;
         public DateTime EndTime;
         public string Summary;
+        public string Details;
         public string Exception;
         public string FullException;
 
@@ -30,12 +31,13 @@ namespace FzCommon
                 StartTime = (DateTime)dr[columnPrefix + "StartTime"],
                 EndTime = (DateTime)dr[columnPrefix + "EndTime"],
                 Summary = SqlHelper.Read<string>(dr, columnPrefix + "Summary"),
+                Details = SqlHelper.Read<string>(dr, columnPrefix + "Details"),
                 Exception = SqlHelper.Read<string>(dr, columnPrefix + "Exception"),
                 FullException = SqlHelper.Read<string>(dr, columnPrefix + "FullException"),
             };
         }
     }
-    
+
     public class JobRunLog
     {
         internal JobRunLog(string jobName, DateTime startTime)
@@ -64,6 +66,10 @@ namespace FzCommon
             cmd.Parameters.AddWithValue("@StartTime", m_startTime);
             cmd.Parameters.AddWithValue("@EndTime", endTime);
             cmd.Parameters.AddWithValue("@Summary", m_summary);
+            if (m_details != null)
+            {
+                cmd.Parameters.AddWithValue("@Details", m_details);
+            }
             if (ex != null)
             {
                 cmd.Parameters.AddWithValue("@Exception", ex.Message);
@@ -117,6 +123,24 @@ namespace FzCommon
             return ret;
         }
 
+        public static async Task<List<RecentJobRun>> GetRecentJobRunLogsWithDetails(SqlConnection sqlcn, DateTime startTime)
+        {
+            List<RecentJobRun> ret = new List<RecentJobRun>();
+            using (SqlCommand cmd = new SqlCommand("GetRecentJobRunLogsWithDetails", sqlcn))
+            {
+                cmd.CommandType = CommandType.StoredProcedure;
+                cmd.Parameters.AddWithValue("@startTime", startTime);
+                using (SqlDataReader dr = cmd.ExecuteReader(CommandBehavior.CloseConnection))
+                {
+                    while (await dr.ReadAsync())
+                    {
+                        ret.Add(RecentJobRun.InstantiateFromReader(dr));
+                    }
+                }
+            }
+            return ret;
+        }
+
         public static async Task<List<RecentJobRun>> GetLatestJobRunLogsAsync(SqlConnection sqlcn)
         {
             List<RecentJobRun> ret = new List<RecentJobRun>();
@@ -133,7 +157,7 @@ namespace FzCommon
             }
             return ret;
         }
-        
+
         public static async Task<List<RecentJobRun>> GetJobRunLogsForNameAsync(SqlConnection sqlcn, string jobName)
         {
             List<RecentJobRun> ret = new List<RecentJobRun>();
@@ -152,10 +176,12 @@ namespace FzCommon
             return ret;
         }
 
-        public string Summary   { get { return m_summary; } set { m_summary = value; }}
+        public string Summary { get { return m_summary; } set { m_summary = value; } }
+        public string? Details { get { return m_details; } set { m_details = value; } }
 
         private string m_jobName;
         private DateTime m_startTime;
         private string m_summary;
+        private string? m_details;
     }
 }

--- a/Libraries/FzCommon/Processors/FloodzillaJob.cs
+++ b/Libraries/FzCommon/Processors/FloodzillaJob.cs
@@ -47,7 +47,7 @@ namespace FzCommon.Processors
             try
             {
                 await this.RunJob(sqlcn, sbDetails, sbSummary);
-                jobEntry.ReportJobSuccess(sqlcn, sbSummary.ToString());
+                jobEntry.ReportJobSuccess(sqlcn, sbSummary.ToString(), sbDetails.ToString());
 
                 // If this fails, just eat the exception -- this is just informational, so we
                 // can lose it without worrying about it.
@@ -61,7 +61,7 @@ namespace FzCommon.Processors
             }
             catch (Exception ex)
             {
-                jobEntry.ReportJobException(sqlcn, ex);
+                jobEntry.ReportJobException(sqlcn, sbDetails.ToString(), ex);
             }
         }
 

--- a/Tools/DumpJobDetails/DumpJobDetails.csproj
+++ b/Tools/DumpJobDetails/DumpJobDetails.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Libraries\FzCommon\FzCommon.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="developer.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+    <!-- This is temporary... -->
+    <None Update="appconfig.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <!-- This is temporary... -->
+  <Target Name="CopyFilesAfterBuild" AfterTargets="Build">
+    <Copy SourceFiles="$(OutDir)appconfig.settings.json" DestinationFolder="$(OutDir)\bin\" />
+  </Target>
+  <Target Name="CopyFilesAfterPublish" BeforeTargets="MSDeployPublish">
+    <Copy SourceFiles="$(OutDir)appconfig.settings.json" DestinationFolder="$(PublishDir)\bin\" />
+  </Target>
+</Project>

--- a/Tools/DumpJobDetails/DumpJobDetails.slnx
+++ b/Tools/DumpJobDetails/DumpJobDetails.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="../../Libraries/FzCommon/FzCommon.csproj" />
+  <Project Path="DumpJobDetails.csproj" />
+</Solution>

--- a/Tools/DumpJobDetails/Program.cs
+++ b/Tools/DumpJobDetails/Program.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections;
+using System.Data;
+using FzCommon;
+using FzCommon.Map;
+using Microsoft.Data.SqlClient;
+
+//$ TODO: Metadata?
+
+async Task DumpJobDetails(SqlConnection sqlcn, DateTime startDate)
+{
+    List<RecentJobRun> runs = await JobRunLog.GetRecentJobRunLogsWithDetails(sqlcn, startDate);
+    foreach (RecentJobRun run in runs)
+    {
+        Console.WriteLine("===================================================================");
+        Console.WriteLine("{0} @ {1}:", run.JobName, run.StartTime);
+        Console.WriteLine("-------------------------");
+        Console.WriteLine(run.Details);
+        Console.WriteLine("===================================================================");
+        Console.WriteLine();
+    }
+}
+
+FzConfig.Initialize();
+using (SqlConnection sqlcn = new(FzConfig.Config[FzConfig.Keys.SqlConnectionString]))
+{
+    await sqlcn.OpenAsync();
+    DateTime startTime = DateTime.UtcNow.AddHours(-6);
+    await DumpJobDetails(sqlcn, startTime);
+}


### PR DESCRIPTION
1) Added a hidden flag to force jobs to save their details in JobRunLogs
2) Instrumented the new USGS fetcher to help diagnose an issue
3) fixed the stored procs (from yesterday's change) that were causing the issue
4) added a simple command-line tool to dump recent job details for convenience
