### PR TITLE
tool to help with purging duplicate sensor readings

### DIFF
--- a/Libraries/FzCommon/SensorReading.cs
+++ b/Libraries/FzCommon/SensorReading.cs
@@ -637,34 +637,47 @@ namespace FzCommon
                                                                                 int skipCount = 0,
                                                                                 int lastReadingId = 0)
         {
-            List<SensorReading> ret = new List<SensorReading>();
             using (SqlConnection sqlcn = new SqlConnection(FzConfig.Config[FzConfig.Keys.SqlConnectionString]))
             {
-                string procName = "GetAllSensorReadingsForLocation";
-                if (skipCount == 0)
+                await sqlcn.OpenAsync();
+                List<SensorReading> ret = await GetAllReadingsForLocation(sqlcn, locationId, readingCount, utcFromDate, utcToDate, skipCount, lastReadingId);
+                await sqlcn.CloseAsync();
+                return ret;
+            }
+        }
+
+        public static async Task<List<SensorReading>> GetAllReadingsForLocation(SqlConnection sqlcn,
+                                                                                int locationId,
+                                                                                int? readingCount,
+                                                                                DateTime? utcFromDate,
+                                                                                DateTime? utcToDate,
+                                                                                int skipCount = 0,
+                                                                                int lastReadingId = 0)
+        {
+            List<SensorReading> ret = new List<SensorReading>();
+            string procName = "GetAllSensorReadingsForLocation";
+            if (skipCount == 0)
+            {
+                procName = "GetAllSensorReadingsForLocationNoSkip";
+            }
+            using (SqlCommand cmd = new SqlCommand(procName, sqlcn))
+            {
+                cmd.CommandType = CommandType.StoredProcedure;
+                cmd.Parameters.Add("@locationId", SqlDbType.Int).Value = locationId;
+                if (readingCount.HasValue) cmd.Parameters.Add("@readingCount", SqlDbType.Int).Value = readingCount;
+                if (utcFromDate.HasValue) cmd.Parameters.Add("@fromTime", SqlDbType.DateTime).Value = utcFromDate;
+                if (utcToDate.HasValue) cmd.Parameters.Add("@toTime", SqlDbType.DateTime).Value = utcToDate;
+                if (skipCount > 0)
                 {
-                    procName = "GetAllSensorReadingsForLocationNoSkip";
+                    cmd.Parameters.Add("@skipCount", SqlDbType.Int).Value = skipCount;
                 }
-                using (SqlCommand cmd = new SqlCommand(procName, sqlcn))
+                cmd.Parameters.Add("@lastReadingId", SqlDbType.Int).Value = lastReadingId;
+                using (SqlDataReader dr = cmd.ExecuteReader())
                 {
-                    cmd.CommandType = CommandType.StoredProcedure;
-                    cmd.Parameters.Add("@locationId", SqlDbType.Int).Value = locationId;
-                    if (readingCount.HasValue) cmd.Parameters.Add("@readingCount", SqlDbType.Int).Value = readingCount;
-                    if (utcFromDate.HasValue) cmd.Parameters.Add("@fromTime", SqlDbType.DateTime).Value = utcFromDate;
-                    if (utcToDate.HasValue) cmd.Parameters.Add("@toTime", SqlDbType.DateTime).Value = utcToDate;
-                    if (skipCount > 0)
+                    while (await dr.ReadAsync())
                     {
-                        cmd.Parameters.Add("@skipCount", SqlDbType.Int).Value = skipCount;
-                    }
-                    cmd.Parameters.Add("@lastReadingId", SqlDbType.Int).Value = lastReadingId;
-                    await sqlcn.OpenAsync();
-                    using (SqlDataReader dr = cmd.ExecuteReader(CommandBehavior.CloseConnection))
-                    {
-                        while (await dr.ReadAsync())
-                        {
-                            SensorReading sr = InstantiateFromReader(dr);
-                            ret.Add(sr);
-                        }
+                        SensorReading sr = InstantiateFromReader(dr);
+                        ret.Add(sr);
                     }
                 }
             }

--- a/Tools/DumpJobDetails/DumpJobDetails.cs
+++ b/Tools/DumpJobDetails/DumpJobDetails.cs
@@ -1,10 +1,7 @@
 ﻿using System.Collections;
 using System.Data;
 using FzCommon;
-using FzCommon.Map;
 using Microsoft.Data.SqlClient;
-
-//$ TODO: Metadata?
 
 async Task DumpJobDetails(SqlConnection sqlcn, DateTime startDate)
 {

--- a/Tools/PurgeDupReadings/PurgeDupReadings.cs
+++ b/Tools/PurgeDupReadings/PurgeDupReadings.cs
@@ -1,0 +1,178 @@
+﻿using System.ComponentModel;
+using System.Data;
+using System.Net.Http.Headers;
+using System.Reflection.Metadata.Ecma335;
+using System.Security;
+using Azure.Storage.Blobs.Models;
+using FzCommon;
+using Microsoft.Data.SqlClient;
+
+// This uses an ad-hoc query because I don't really want to bake this into a sproc -- it should
+// only be necessary from this tool.
+const string ALL_DUPSETS_QUERY = "SELECT COUNT(Id) as Count, LocationId, Timestamp FROM SensorReadings GROUP BY LocationId, Timestamp HAVING COUNT(Id) > 1 ORDER BY LocationId, Timestamp";
+async Task<Dictionary<int, List<DupReadingSet>>> GetDupSets(SqlConnection sqlcn)
+{
+    Dictionary<int, List<DupReadingSet>> ret = [];
+    int count = 0;
+    using (SqlCommand cmd = new(ALL_DUPSETS_QUERY, sqlcn))
+    {
+        using SqlDataReader rdr = await cmd.ExecuteReaderAsync();
+        while (await rdr.ReadAsync())
+        {
+            DupReadingSet dup = DupReadingSet.FromReader(rdr);
+            if (!ret.ContainsKey(dup.LocationId))
+            {
+                ret[dup.LocationId] = [];
+            }
+            count++;
+            ret[dup.LocationId].Add(dup);
+        }
+    }
+    Console.WriteLine("Loaded {0} sets of duplicate readings...", count);
+    return ret;
+}
+
+async Task<List<SensorReading>> GetAllPossibleSensorReadings(SqlConnection sqlcn, List<DupReadingSet> allDupsForLocation)
+{
+    int locationId = -1;
+    List<SensorReading> ret = [];
+    DateTime endTime = DateTime.MinValue;
+    DateTime startTime = DateTime.MaxValue;
+    foreach (DupReadingSet dup in allDupsForLocation)
+    {
+        if (locationId == -1)
+        {
+            locationId = dup.LocationId;
+        }
+        else
+        {
+            if (locationId != dup.LocationId)
+            {
+                throw new ApplicationException("DupReadingSet had wrong locationId!?");
+            }
+        }
+        // Be paranoid, don't assume these are in timestamp order (although they should be)...
+        if (endTime < dup.Timestamp)
+        {
+            endTime = dup.Timestamp;
+        }
+        if (startTime > dup.Timestamp)
+        {
+            startTime = dup.Timestamp;
+        }
+    }
+    List<SensorReading> readings = await SensorReading.GetAllReadingsForLocation(sqlcn, locationId, null, startTime, endTime);
+    foreach (SensorReading reading in readings)
+    {
+        ret.Add(reading);
+    }
+    // Sort by Timestamp ascending, Id ascending to make finding matches easier.
+    ret.Sort((a, b) =>
+    {
+        if (a.Timestamp == b.Timestamp)
+        {
+            return a.Id - b.Id;
+        }
+        return (int)((a.Timestamp - b.Timestamp).TotalMilliseconds);
+    });
+    return ret;
+}
+
+List<SensorReading> GetMatchingReadings(List<SensorReading> allReadings, DupReadingSet set)
+{
+    List<SensorReading> ret = [];
+    for (int i = 0; i < allReadings.Count; i++)
+    {
+        if (allReadings[i].Timestamp > set.Timestamp)
+        {
+            return ret;
+        }
+        if (allReadings[i].Timestamp == set.Timestamp)
+        {
+            ret.Add(allReadings[i]);
+        }
+    }
+    return ret;
+}
+
+SensorReading FindBestReadingInSet(List<SensorReading> readings)
+{
+    int bestIndex = -1;
+    for (int i = 0; i < readings.Count; i++)
+    {
+        // Current criteria: earliest (lowest-ID) reading that has both WaterHeight and WaterDischarge is the "best"
+        if (readings[i].WaterHeight.HasValue && readings[i].WaterDischarge.HasValue)
+        {
+            bestIndex = i;
+            break;
+        }
+    }
+    if (bestIndex == -1)
+    {
+        throw new ApplicationException(String.Format("ERROR: Reading set for {0} @ {1} doesn't have a complete reading", readings[0].LocationId, readings[0].Timestamp));
+    }
+    return readings[bestIndex];
+}
+
+const int COUNT_PER_BATCH = 5;
+int dupSetCount = 0;
+async Task ProcessReadingSets(SqlConnection sqlcn)
+{
+    Dictionary<int, List<DupReadingSet>> dups = await GetDupSets(sqlcn);
+    foreach (int locId in dups.Keys)
+    {
+        List<DupReadingSet> sets = dups[locId];
+        List<SensorReading> allReadings = await GetAllPossibleSensorReadings(sqlcn, sets);
+
+        foreach (DupReadingSet set in sets)
+        {
+            List<SensorReading> readings = GetMatchingReadings(allReadings, set);
+            SensorReading best = FindBestReadingInSet(readings);
+            // NOTE: Yes, I'm using String.Format to build a SQL query.  This is ok because (a) I control the format and
+            // the inputs, and (b) it's not going to be executed directly; it's going to be manually executed by a human
+            // and verified before and after...
+            string timestampString = set.Timestamp.ToString("yyyy-MM-dd HH:mm:ss.fff");
+            Console.WriteLine();
+            Console.WriteLine("SELECT Id,Timestamp,LocationId,DeviceId,DistanceReading,WaterHeight,WaterHeightFeet,WaterDischarge,IsDeleted FROM SensorReadings WHERE LocationId={0} AND Timestamp='{1}' ORDER BY Id ASC",
+                              set.LocationId, timestampString);
+            Console.WriteLine("-- Expected count: {0}", readings.Count);
+            Console.WriteLine("-- Expected readings: {0}", String.Join(',', readings.Select(r => r.Id)));
+            Console.WriteLine("-- DELETE FROM SensorReadings WHERE LocationId={0} AND Timestamp='{1}' AND Id <> {2}",
+                              set.LocationId, timestampString, best.Id);
+            Console.WriteLine("SELECT Id,Timestamp,LocationId,DeviceId,DistanceReading,WaterHeight,WaterHeightFeet,WaterDischarge,IsDeleted FROM SensorReadings WHERE LocationId={0} AND Timestamp='{1}' AND Id <> {2}",
+                              set.LocationId, timestampString, best.Id);
+            Console.WriteLine();
+            Console.WriteLine("--================================================================");
+            if (++dupSetCount >= COUNT_PER_BATCH)
+            {
+                return;
+            }
+        }
+    }
+}
+
+Console.WriteLine("--================================================================");
+FzConfig.Initialize();
+using (SqlConnection sqlcn = new(FzConfig.Config[FzConfig.Keys.SqlConnectionString]))
+{
+    await sqlcn.OpenAsync();
+    await ProcessReadingSets(sqlcn);
+    await sqlcn.CloseAsync();
+}
+
+public class DupReadingSet
+{
+    public int Count;
+    public int LocationId;
+    public DateTime Timestamp;
+
+    public static DupReadingSet FromReader(SqlDataReader dr)
+    {
+        return new()
+        {
+            Count = SqlHelper.Read<int>(dr, "Count"),
+            LocationId = SqlHelper.Read<int>(dr, "LocationId"),
+            Timestamp = SqlHelper.Read<DateTime>(dr, "Timestamp"),
+        };
+    }
+}

--- a/Tools/PurgeDupReadings/PurgeDupReadings.csproj
+++ b/Tools/PurgeDupReadings/PurgeDupReadings.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Libraries\FzCommon\FzCommon.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="developer.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+    <!-- This is temporary... -->
+    <None Update="appconfig.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <!-- This is temporary... -->
+  <Target Name="CopyFilesAfterBuild" AfterTargets="Build">
+    <Copy SourceFiles="$(OutDir)appconfig.settings.json" DestinationFolder="$(OutDir)\bin\" />
+  </Target>
+  <Target Name="CopyFilesAfterPublish" BeforeTargets="MSDeployPublish">
+    <Copy SourceFiles="$(OutDir)appconfig.settings.json" DestinationFolder="$(PublishDir)\bin\" />
+  </Target>
+</Project>

--- a/Tools/PurgeDupReadings/PurgeDupReadings.slnx
+++ b/Tools/PurgeDupReadings/PurgeDupReadings.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="../../Libraries/FzCommon/FzCommon.csproj" />
+  <Project Path="PurgeDupReadings.csproj" />
+</Solution>


### PR DESCRIPTION
We had a couple issues where USGS gauges were getting duplicated readings (i.e. more than one reading for a given gauge at a given timestamp).  (one issue was my bug, one is still unknown)

tools/PurgeDupReadings is a tool to find these and spit out some SQL scripts to help with manually reviewing and deleting the dup entries.

Also included: minor tweak to some SQL-related code in SensorReading, and a file rename for another tool.